### PR TITLE
Add selectable topics and word list screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:charadex/data.dart';
 import 'package:charadex/screens/settings.dart';
 import 'package:charadex/screens/tutorial.dart';
+import 'package:charadex/screens/word_list_screen.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -16,6 +17,7 @@ class _HomeScreenState extends State<HomeScreen> {
   final purple = const Color(0xFF9B5EFF);
 
   String selectedMenuId = "all";
+  final Set<String> selectedImageIds = {};
 
   @override
   Widget build(BuildContext context) {
@@ -95,46 +97,68 @@ class _HomeScreenState extends State<HomeScreen> {
                   mainAxisSpacing: 10,
                   childAspectRatio: 3 / 4,
                   children: filteredImages.map((item) {
-                    return Stack(
-                      children: [
-                        Container(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(12),
-                            image: DecorationImage(
-                              image: AssetImage(item["imagePath"]),
-                              fit: BoxFit.cover,
-                            ),
+                    final isSelected = selectedImageIds.contains(item['id']);
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          if (isSelected) {
+                            selectedImageIds.remove(item['id']);
+                          } else {
+                            selectedImageIds.add(item['id']);
+                          }
+                        });
+                      },
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(12),
+                          border: Border.all(
+                            color: isSelected ? purple : Colors.transparent,
+                            width: 3,
                           ),
                         ),
-                        Align(
-                          alignment: Alignment.bottomCenter,
-                          child: Container(
-                            width: double.infinity,
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 8, vertical: 6),
-                            decoration: const BoxDecoration(
-                              borderRadius: BorderRadius.vertical(
-                                  bottom: Radius.circular(12)),
-                              color: Colors.transparent,
-                            ),
-                            child: Text(
-                              item["id"].toString(),
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                                shadows: [
-                                  Shadow(
-                                    blurRadius: 2,
-                                    color: Colors.black,
-                                    offset: Offset(0.5, 0.5),
-                                  )
-                                ],
+                        child: Stack(
+                          children: [
+                            Container(
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(12),
+                                image: DecorationImage(
+                                  image: AssetImage(item["imagePath"]),
+                                  fit: BoxFit.cover,
+                                ),
                               ),
                             ),
-                          ),
+                            Align(
+                              alignment: Alignment.bottomCenter,
+                              child: Container(
+                                width: double.infinity,
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 8, vertical: 6),
+                                decoration: const BoxDecoration(
+                                  borderRadius: BorderRadius.vertical(
+                                      bottom: Radius.circular(12)),
+                                  color: Colors.transparent,
+                                ),
+                                child: Text(
+                                  item["id"].toString(),
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontWeight: FontWeight.bold,
+                                    shadows: [
+                                      Shadow(
+                                        blurRadius: 2,
+                                        color: Colors.black,
+                                        offset: Offset(0.5, 0.5),
+                                      )
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                      ],
+                      ),
                     );
                   }).toList(),
                 ),
@@ -157,7 +181,21 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
             onPressed: () {
-              debugPrint("Start button pressed");
+              final selectedItems = selectedImageIds.isEmpty
+                  ? imageItems
+                  : imageItems
+                      .where((item) => selectedImageIds.contains(item['id']))
+                      .toList();
+              final words = <String>[];
+              for (final item in selectedItems) {
+                words.addAll(List<String>.from(item['words'] as List));
+              }
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => WordListScreen(words: words),
+                ),
+              );
             },
             label: const Text(
               "Start",

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -37,6 +37,26 @@ class TutorialScreen extends StatelessWidget {
             step: 3,
             heading: "Kippen zum Steuern",
             description: "Nach unten = richtig\nNach oben = überspringen",
+            extras: [
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: Image.asset(
+                      'assets/tutorial/correct.png',
+                      height: 100,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Image.asset(
+                      'assets/tutorial/incorrect.png',
+                      height: 100,
+                    ),
+                  ),
+                ],
+              ),
+            ],
           ),
           const SizedBox(height: 16),
           _tutorialBox(
@@ -53,6 +73,7 @@ class TutorialScreen extends StatelessWidget {
     required int step,
     required String heading,
     required String description,
+    List<Widget> extras = const [],
   }) {
     return Container(
       decoration: BoxDecoration(
@@ -94,6 +115,7 @@ class TutorialScreen extends StatelessWidget {
                     fontSize: 14,
                   ),
                 ),
+                ...extras,
               ],
             ),
           )

--- a/lib/screens/word_list_screen.dart
+++ b/lib/screens/word_list_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class WordListScreen extends StatelessWidget {
+  final List<String> words;
+  const WordListScreen({super.key, required this.words});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F0F1C),
+      appBar: AppBar(
+        title: const Text('Wörter'),
+        backgroundColor: const Color(0xFF0F0F1C),
+      ),
+      body: ListView.builder(
+        itemCount: words.length,
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(
+              words[index],
+              style: const TextStyle(color: Colors.white),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow selecting images on the home screen
- animated purple border shows selected topics
- start button opens a list of words for the chosen topics

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d64b0007c83299f946de4aec38389