### PR TITLE
Implement round history dots and fix borders

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -38,7 +38,7 @@ const List<Map<String, dynamic>> menuItems = [
 const List<Map<String, dynamic>> imageItems = [
   {
     "id": "animals",
-    "titleKey": "animals",
+    "titleKeys": ["animals"],
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/animals.png",
     "words": [
@@ -49,7 +49,7 @@ const List<Map<String, dynamic>> imageItems = [
   },
   {
     "id": "basketball",
-    "titleKey": "basketball",
+    "titleKeys": ["basketball"],
     "fitMenuItemId": "sport",
     "imagePath": "assets/topics/basketball.png",
     "words": [
@@ -60,7 +60,7 @@ const List<Map<String, dynamic>> imageItems = [
   },
   {
     "id": "cars",
-    "titleKey": "cars",
+    "titleKeys": ["cars", "autos"],
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/cars.png",
     "words": [
@@ -70,7 +70,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "films",
-    "titleKey": "films",
+    "titleKeys": ["films"],
     "fitMenuItemId": "films",
     "imagePath": "assets/topics/films.png",
     "words": [
@@ -80,7 +80,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "football",
-    "titleKey": "football",
+    "titleKeys": ["football"],
     "fitMenuItemId": "sport",
     "imagePath": "assets/topics/football.png",
     "words": [
@@ -90,7 +90,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "geography",
-    "titleKey": "geography",
+    "titleKeys": ["geography"],
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/geography.png",
     "words": [
@@ -100,7 +100,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "history",
-    "titleKey": "history",
+    "titleKeys": ["history"],
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/history.png",
     "words": [
@@ -110,7 +110,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "jobs",
-    "titleKey": "jobs",
+    "titleKeys": ["jobs"],
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/jobs.png",
     "words": [
@@ -120,7 +120,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "music",
-    "titleKey": "music",
+    "titleKeys": ["music"],
     "fitMenuItemId": "films",
     "imagePath": "assets/topics/music.png",
     "words": [
@@ -130,7 +130,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "series",
-    "titleKey": "series",
+    "titleKeys": ["series"],
     "fitMenuItemId": "films",
     "imagePath": "assets/topics/series.png",
     "words": [
@@ -140,7 +140,7 @@ const List<Map<String, dynamic>> imageItems = [
     ],
   },{
     "id": "sport",
-    "titleKey": "sport",
+    "titleKeys": ["sport"],
     "fitMenuItemId": "sport",
     "imagePath": "assets/topics/sport.png",
     "words": [

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,7 +14,7 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   final backgroundColor = const Color(0xFF0F0F1C);
   final cardColor = const Color(0xFF1E1E2D);
-  final purple = const Color(0xFF9B5EFF);
+  final Color highlightColor = Colors.amber[600]!;
 
   String selectedMenuId = "all";
   final Set<String> selectedImageIds = {};
@@ -113,21 +113,16 @@ class _HomeScreenState extends State<HomeScreen> {
                         decoration: BoxDecoration(
                           borderRadius: BorderRadius.circular(12),
                           border: Border.all(
-                            color: isSelected ? purple : Colors.transparent,
+                            color: isSelected ? highlightColor! : Colors.transparent,
                             width: 3,
+                          ),
+                          image: DecorationImage(
+                            image: AssetImage(item["imagePath"]),
+                            fit: BoxFit.cover,
                           ),
                         ),
                         child: Stack(
                           children: [
-                            Container(
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(12),
-                                image: DecorationImage(
-                                  image: AssetImage(item["imagePath"]),
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
-                            ),
                             Align(
                               alignment: Alignment.bottomCenter,
                               child: Container(

--- a/lib/screens/results_screen.dart
+++ b/lib/screens/results_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import 'word_list_screen.dart';
+
+class ResultsScreen extends StatelessWidget {
+  final List<WordResult> results;
+  const ResultsScreen({super.key, required this.results});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF0F0F1C),
+      appBar: AppBar(
+        title: const Text('Ergebnis'),
+        backgroundColor: const Color(0xFF0F0F1C),
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              itemCount: results.length,
+              itemBuilder: (context, index) {
+                final res = results[index];
+                return ListTile(
+                  title: Text(
+                    res.word,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: res.correct ? Colors.green : Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Zur\u00fcck zum Men\u00fc'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- show recent word results as colored dots under the buttons
- center the results list and add a back button
- allow topics to define multiple `titleKeys`
- fix yellow selection border on the home screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d713f5ff88329a9001b7681761a8c