### PR TITLE
Fix orientation, rename screens, and update texts

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -149,14 +149,14 @@ const List<Map<String, dynamic>> imageItems = [
     "words": ["Walter White", "meth", "Heisenberg", "chemistry", "New Mexico"],
   },
   {
-    "id": "disney_kids",
+    "id": "disney",
     "label": "Disney",
     "fitMenuItemId": "kids",
     "imagePath": "assets/topics/films/disney.jpeg",
     "words": ["Mickey", "Goofy", "Frozen", "Moana", "Aladdin"],
   },
   {
-    "id": "disney_films",
+    "id": "disney",
     "label": "Disney",
     "fitMenuItemId": "films",
     "imagePath": "assets/topics/films/disney.jpeg",

--- a/lib/screens/game_end_screen.dart
+++ b/lib/screens/game_end_screen.dart
@@ -1,24 +1,38 @@
 import 'package:flutter/material.dart';
 
-import 'word_list_screen.dart';
+import 'game_screen.dart';
+import 'package:flutter/services.dart';
 
-class ResultsScreen extends StatelessWidget {
+class GameEndScreen extends StatelessWidget {
   final List<WordResult> results;
-  const ResultsScreen({super.key, required this.results});
+  const GameEndScreen({super.key, required this.results});
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+    ]);
     return Scaffold(
       backgroundColor: const Color(0xFF0F0F1C),
       appBar: AppBar(
         title: const Text(
-          'Ergebnis',
+          'Results',
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
         backgroundColor: const Color(0xFF0F0F1C),
       ),
       body: Column(
         children: [
+          const SizedBox(height: 16),
+          const Text(
+            'Congratulations',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
           Expanded(
             child: ListView.builder(
               itemCount: results.length,
@@ -59,7 +73,7 @@ class ResultsScreen extends StatelessWidget {
                 ),
                 onPressed: () => Navigator.pop(context),
                 child: const Text(
-                  'Zur\u00fcck zum Men\u00fc',
+                  'Back to Menu',
                   style: TextStyle(
                     color: Colors.black,
                     fontWeight: FontWeight.bold,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -4,14 +4,15 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import '../game_settings.dart';
-import 'results_screen.dart';
+import 'game_end_screen.dart';
+import 'package:flutter/services.dart';
 
-class WordListScreen extends StatefulWidget {
+class GameScreen extends StatefulWidget {
   final List<String> words;
-  const WordListScreen({super.key, required this.words});
+  const GameScreen({super.key, required this.words});
 
   @override
-  State<WordListScreen> createState() => _WordListScreenState();
+  State<GameScreen> createState() => _GameScreenState();
 }
 
 class WordResult {
@@ -20,7 +21,7 @@ class WordResult {
   WordResult(this.word, this.correct);
 }
 
-class _WordListScreenState extends State<WordListScreen> {
+class _GameScreenState extends State<GameScreen> {
   late List<String> _remaining;
   late String _currentWord;
   late Duration _timeLeft;
@@ -97,7 +98,7 @@ class _WordListScreenState extends State<WordListScreen> {
     Navigator.pushReplacement(
       context,
       MaterialPageRoute(
-        builder: (context) => ResultsScreen(results: _results),
+        builder: (context) => GameEndScreen(results: _results),
       ),
     );
   }
@@ -116,6 +117,10 @@ class _WordListScreenState extends State<WordListScreen> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
     return Scaffold(
       backgroundColor: _background,
       appBar: AppBar(
@@ -127,13 +132,27 @@ class _WordListScreenState extends State<WordListScreen> {
         centerTitle: true,
       ),
       body: Center(
-        child: Text(
-          _currentWord,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 32,
-            fontWeight: FontWeight.bold,
-          ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Congratulations',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _currentWord,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
       ),
       bottomNavigationBar: Padding(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,7 +1,8 @@
 import 'package:charadex/data.dart';
 import 'package:charadex/screens/settings.dart';
 import 'package:charadex/screens/tutorial.dart';
-import 'package:charadex/screens/word_list_screen.dart';
+import 'package:charadex/screens/game_screen.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -21,11 +22,14 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+    ]);
     final filteredImages = selectedMenuId == "all"
         ? imageItems
         : imageItems
-        .where((item) => item["fitMenuItemId"] == selectedMenuId)
-        .toList();
+            .where((item) => item["fitMenuItemId"] == selectedMenuId)
+            .toList();
 
     return Scaffold(
       backgroundColor: backgroundColor,
@@ -190,14 +194,17 @@ class _HomeScreenState extends State<HomeScreen> {
                   : imageItems
                       .where((item) => selectedImageIds.contains(item['id']))
                       .toList();
+              final uniqueItems = {
+                for (var item in selectedItems) item['id']: item
+              }.values.toList();
               final words = <String>[];
-              for (final item in selectedItems) {
+              for (final item in uniqueItems) {
                 words.addAll(List<String>.from(item['words'] as List));
               }
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => WordListScreen(words: words),
+                  builder: (context) => GameScreen(words: words),
                 ),
               );
             },

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -2,6 +2,7 @@ import 'package:charadex/screens/tutorial.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/services.dart';
 import '../game_settings.dart';
 
 class SettingsScreen extends StatefulWidget {
@@ -12,7 +13,7 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  String _selectedLanguage = 'Deutsch';
+  String _selectedLanguage = 'English';
   Duration _selectedDuration = GameSettings.roundDuration;
 
   final backgroundColor = const Color(0xFF0F0F1C);
@@ -27,41 +28,44 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+    ]);
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: AppBar(
         backgroundColor: backgroundColor,
-        title: const Text("Einstellungen"),
+        title: const Text("Settings"),
         foregroundColor: Colors.white,
         elevation: 0,
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          // 🔹 Einstellungen-Kategorie
-          const Text("Einstellungen",
+          // 🔹 Settings category
+          const Text("Settings",
               style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
           const SizedBox(height: 12),
 
-          // Sprache
+          // Language
           _settingsTile(
             icon: Icons.language,
-            title: "Sprache",
+            title: "Language",
             value: _selectedLanguage,
             onTap: () {
               setState(() {
                 _selectedLanguage =
-                _selectedLanguage == 'Deutsch' ? 'Englisch' : 'Deutsch';
+                _selectedLanguage == 'English' ? 'German' : 'English';
               });
             },
           ),
 
           const SizedBox(height: 12),
 
-          // Spielzeit (Cupertino Timer Picker)
+          // Round time (Cupertino Timer Picker)
           _settingsTile(
             icon: Icons.timer,
-            title: "Spielzeit",
+            title: "Round Time",
             value: _formatDuration(_selectedDuration),
             onTap: () {
               showModalBottomSheet(
@@ -102,8 +106,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // Tutorial-Link
           _settingsTile(
             icon: Icons.menu_book,
-            title: "So wird gespielt",
-            value: "Regeln lernen",
+            title: "How to Play",
+            value: "Learn the rules",
             onTap: () {
               Navigator.push(
                 context,
@@ -117,19 +121,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 24),
 
           // 🔹 App-Informationen
-          const Text("App-Informationen",
+          const Text("App Information",
               style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
           const SizedBox(height: 12),
 
           _infoTile(
             icon: Icons.info_outline,
-            title: "App-Version",
+            title: "App Version",
             value: "1.1.0",
           ),
 
           const SizedBox(height: 12),
 
-          // App bewerten
+          // Rate App
           InkWell(
             onTap: () async {
               final url = Uri.parse("https://www.vucak.at");
@@ -150,7 +154,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   const SizedBox(width: 16),
                   const Expanded(
                     child: Text(
-                      "App bewerten",
+                      "Rate the App",
                       style: TextStyle(
                         color: Colors.white,
                         fontWeight: FontWeight.bold,

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class TutorialScreen extends StatelessWidget {
   const TutorialScreen({super.key});
@@ -8,35 +9,38 @@ class TutorialScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+    ]);
     return Scaffold(
       backgroundColor: backgroundColor,
       appBar: AppBar(
         backgroundColor: backgroundColor,
         foregroundColor: Colors.white,
         elevation: 0,
-        title: const Text("So wird gespielt"),
+        title: const Text("How to Play"),
       ),
       body: ListView(
         padding: const EdgeInsets.all(20),
         children: [
           _tutorialBox(
             step: 1,
-            heading: "Kategorie wählen",
+            heading: "Choose a category",
             description:
-            "Such dir eine oder mehrere Kategorien aus und stelle die Rundenzeit ein.",
+                "Pick one or more categories and set the round time.",
           ),
           const SizedBox(height: 16),
           _tutorialBox(
             step: 2,
-            heading: "Handy auf die Stirn",
+            heading: "Phone on the forehead",
             description:
-            "Halte das Handy auf die Stirn. Deine Mitspieler sollten das Wort sehen können.",
+                "Hold the phone to your forehead so your team can read the word.",
           ),
           const SizedBox(height: 16),
           _tutorialBox(
             step: 3,
-            heading: "Kippen zum Steuern",
-            description: "Nach unten = richtig\nNach oben = überspringen",
+            heading: "Tilt to control",
+            description: "Down = correct\nUp = skip",
             extras: [
               const SizedBox(height: 12),
               Row(
@@ -61,8 +65,8 @@ class TutorialScreen extends StatelessWidget {
           const SizedBox(height: 16),
           _tutorialBox(
             step: 4,
-            heading: "Los geht's!",
-            description: "Viel Spaß beim Raten!",
+            heading: "Let's go!",
+            description: "Have fun guessing!",
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- rename `word_list_screen.dart` to `game_screen.dart`
- rename `results_screen.dart` to `game_end_screen.dart`
- keep Disney selected across Kids and Films filters
- force orientation for each screen
- translate all UI text to English
- display "Congratulations" on game and results screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e6815645483299087033a124724b7