### PR TITLE
Add movements setting and update game UI

### DIFF
--- a/lib/game_settings.dart
+++ b/lib/game_settings.dart
@@ -2,7 +2,9 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class GameSettings {
   static const _durationKey = 'roundDuration';
+  static const _movementsKey = 'movementsEnabled';
   static Duration roundDuration = const Duration(seconds: 60);
+  static bool movementsEnabled = false;
 
   static Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -10,10 +12,12 @@ class GameSettings {
     if (sec != null) {
       roundDuration = Duration(seconds: sec);
     }
+    movementsEnabled = prefs.getBool(_movementsKey) ?? false;
   }
 
   static Future<void> save() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_durationKey, roundDuration.inSeconds);
+    await prefs.setBool(_movementsKey, movementsEnabled);
   }
 }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -28,6 +28,7 @@ class _GameScreenState extends State<GameScreen> {
   Timer? _timer;
   Timer? _countdownTimer;
   int _countdown = 3;
+  String _countdownDisplay = '3';
   bool _showCountdown = true;
   Color _background = const Color(0xFF0F0F1C);
   final List<WordResult> _results = [];
@@ -47,15 +48,23 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _startCountdown() {
+    _countdownDisplay = '$_countdown';
     _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_countdown == 1) {
+      if (_countdown == 0) {
         timer.cancel();
         setState(() {
-          _showCountdown = false;
+          _countdownDisplay = 'Start';
         });
-        _timer = Timer.periodic(const Duration(seconds: 1), _tick);
+        Future.delayed(const Duration(seconds: 1), () {
+          if (!mounted) return;
+          setState(() {
+            _showCountdown = false;
+          });
+          _timer = Timer.periodic(const Duration(seconds: 1), _tick);
+        });
       } else {
         setState(() {
+          _countdownDisplay = '$_countdown';
           _countdown -= 1;
         });
       }
@@ -148,40 +157,56 @@ class _GameScreenState extends State<GameScreen> {
       body: SafeArea(
         child: Stack(
           children: [
-            if (!_showCountdown)
-              Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      _formatTime(_timeLeft),
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
-                      ),
+            if (!_showCountdown) ...[
+              Align(
+                alignment: Alignment.topCenter,
+                child: Container(
+                  margin: const EdgeInsets.only(top: 8),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: Colors.black,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    _formatTime(_timeLeft),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      _currentWord,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 32,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
               ),
+              Center(
+                child: Text(
+                  _currentWord,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 48,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
             if (_showCountdown)
               Center(
                 child: AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 500),
-                  transitionBuilder: (child, animation) =>
-                      ScaleTransition(scale: animation, child: child),
+                  duration: const Duration(milliseconds: 800),
+                  transitionBuilder: (child, animation) {
+                    final fade = CurvedAnimation(
+                        parent: animation, curve: Curves.easeOut);
+                    final scale = Tween<double>(begin: 1, end: 2)
+                        .animate(animation);
+                    return FadeTransition(
+                      opacity: fade,
+                      child: ScaleTransition(scale: scale, child: child),
+                    );
+                  },
                   child: Text(
-                    '$_countdown',
-                    key: ValueKey(_countdown),
+                    _countdownDisplay,
+                    key: ValueKey(_countdownDisplay),
                     style: const TextStyle(
                       color: Colors.white,
                       fontSize: 72,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:charadex/screens/tutorial.dart';
 import 'package:charadex/screens/game_screen.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
+import '../game_settings.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -37,15 +38,18 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         backgroundColor: backgroundColor,
         elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.help_outline, color: Colors.white),
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(builder: (context) => const TutorialScreen()),
-            );
-          },
-        ),
+        leading: GameSettings.movementsEnabled
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.help_outline, color: Colors.white),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => const TutorialScreen()),
+                  );
+                },
+              ),
         centerTitle: true,
         title: const Text(
           'Charade',
@@ -54,17 +58,20 @@ class _HomeScreenState extends State<HomeScreen> {
             fontWeight: FontWeight.bold,
           ),
         ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.settings, color: Colors.white),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => const SettingsScreen()),
-              );
-            },
-          ),
-        ],
+        actions: GameSettings.movementsEnabled
+            ? null
+            : [
+                IconButton(
+                  icon: const Icon(Icons.settings, color: Colors.white),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const SettingsScreen()),
+                    );
+                  },
+                ),
+              ],
       ),
       body: SafeArea(
         child: SingleChildScrollView(
@@ -177,51 +184,54 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
         ),
       ),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.fromLTRB(32, 15, 32, 30),
-        child: SizedBox(
-          height: 50,
-          width: double.infinity,
-          child: ElevatedButton.icon(
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.amber[600],
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(30),
-              ),
-            ),
-            onPressed: () {
-              final selectedItems = selectedImageIds.isEmpty
-                  ? imageItems
-                  : imageItems
-                      .where((item) => selectedImageIds.contains(item['id']))
-                      .toList();
-              final uniqueItems = {
-                for (var item in selectedItems) item['id']: item
-              }.values.toList();
-              final words = <String>[];
-              for (final item in uniqueItems) {
-                words.addAll(List<String>.from(item['words'] as List));
-              }
-              SystemChrome.setPreferredOrientations([
-                DeviceOrientation.landscapeRight,
-              ]);
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => GameScreen(words: words),
+      bottomNavigationBar: GameSettings.movementsEnabled
+          ? null
+          : Padding(
+              padding: const EdgeInsets.fromLTRB(32, 15, 32, 30),
+              child: SizedBox(
+                height: 50,
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.amber[600],
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                  ),
+                  onPressed: () {
+                    final selectedItems = selectedImageIds.isEmpty
+                        ? imageItems
+                        : imageItems
+                            .where(
+                                (item) => selectedImageIds.contains(item['id']))
+                            .toList();
+                    final uniqueItems = {
+                      for (var item in selectedItems) item['id']: item
+                    }.values.toList();
+                    final words = <String>[];
+                    for (final item in uniqueItems) {
+                      words.addAll(List<String>.from(item['words'] as List));
+                    }
+                    SystemChrome.setPreferredOrientations([
+                      DeviceOrientation.landscapeRight,
+                    ]);
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => GameScreen(words: words),
+                      ),
+                    );
+                  },
+                  label: const Text(
+                    "Start",
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
                 ),
-              );
-            },
-            label: const Text(
-              "Start",
-              style: TextStyle(
-                color: Colors.black,
-                fontWeight: FontWeight.bold,
               ),
             ),
-          ),
-        ),
-      ),
     );
   }
 

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -15,6 +15,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   String _selectedLanguage = 'English';
   Duration _selectedDuration = GameSettings.roundDuration;
+  bool _movements = GameSettings.movementsEnabled;
 
   final backgroundColor = const Color(0xFF0F0F1C);
   final cardColor = const Color(0xFF1E1E2D);
@@ -24,6 +25,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   void initState() {
     super.initState();
     _selectedDuration = GameSettings.roundDuration;
+    _movements = GameSettings.movementsEnabled;
   }
 
   @override
@@ -45,7 +47,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // 🔹 Settings category
           const Text("Settings",
               style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 12),
 
           // Language
           _settingsTile(
@@ -60,7 +61,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
 
-          const SizedBox(height: 12),
 
           // Round time (Cupertino Timer Picker)
           _settingsTile(
@@ -99,6 +99,43 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 },
               );
             },
+          ),
+
+          const SizedBox(height: 12),
+
+          // Movements toggle
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+            decoration: BoxDecoration(
+              color: cardColor,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.directions_run, color: Colors.amber[600]),
+                const SizedBox(width: 16),
+                const Expanded(
+                  child: Text(
+                    'Movements',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: _movements,
+                  activeColor: Colors.amber,
+                  onChanged: (val) {
+                    setState(() {
+                      _movements = val;
+                      GameSettings.movementsEnabled = val;
+                    });
+                    GameSettings.save();
+                  },
+                ),
+              ],
+            ),
           ),
 
           const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- persist new `movementsEnabled` option in `GameSettings`
- add movements switch to settings screen
- hide help, settings and start controls on home screen when movements enabled
- restyle game countdown and timer layout

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e74b1b49c8329adca293b43244503