### PR TITLE
Add motion controls and instructions overlay

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   url_launcher: ^6.1.7
   shared_preferences: ^2.2.2
+  sensors_plus: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add sensors_plus dependency
- implement a start/instruction overlay in `GameScreen`
- hook up accelerometer tilt controls when movements are disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e7ea6f9248329b6ea0e22efde6942