### PR TITLE
Fix tutorial start and end screen UI

### DIFF
--- a/lib/screens/game_end_screen.dart
+++ b/lib/screens/game_end_screen.dart
@@ -16,7 +16,7 @@ class GameEndScreen extends StatelessWidget {
       backgroundColor: const Color(0xFF0F0F1C),
       appBar: AppBar(
         title: const Text(
-          'Results',
+          'Congratulations',
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
         backgroundColor: const Color(0xFF0F0F1C),
@@ -28,7 +28,7 @@ class GameEndScreen extends StatelessWidget {
             'Congratulations',
             style: TextStyle(
               color: Colors.white,
-              fontSize: 20,
+              fontSize: 24,
               fontWeight: FontWeight.bold,
             ),
           ),
@@ -39,9 +39,9 @@ class GameEndScreen extends StatelessWidget {
               itemBuilder: (context, index) {
                 final res = results[index];
                 return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
                   child: Container(
-                    padding: const EdgeInsets.all(12),
+                    padding: const EdgeInsets.all(16),
                     decoration: BoxDecoration(
                       color: Colors.black,
                       borderRadius: BorderRadius.circular(12),
@@ -52,6 +52,7 @@ class GameEndScreen extends StatelessWidget {
                       style: TextStyle(
                         color: res.correct ? Colors.red : Colors.green,
                         fontWeight: FontWeight.bold,
+                        fontSize: 20,
                       ),
                     ),
                   ),
@@ -60,7 +61,7 @@ class GameEndScreen extends StatelessWidget {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(20),
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 40),
             child: SizedBox(
               width: double.infinity,
               height: 50,

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -111,23 +111,22 @@ class _GameScreenState extends State<GameScreen> {
       if (z > 7) {
         _processingTilt = true;
         _tiltCorrect = true;
-        _timer?.cancel();
         setState(() {
           _background = Colors.red;
         });
+        HapticFeedback.mediumImpact();
       } else if (z < -7) {
         _processingTilt = true;
         _tiltCorrect = false;
-        _timer?.cancel();
         setState(() {
           _background = Colors.green;
         });
+        HapticFeedback.mediumImpact();
       }
     } else {
       if (z.abs() < 3) {
         _processingTilt = false;
         final res = _tiltCorrect;
-        _startTimer();
         _nextWord(res);
       }
     }
@@ -309,7 +308,7 @@ class _GameScreenState extends State<GameScreen> {
                         ],
                       )
                     : const Text(
-                        'Hold the phone to your forehead. Tilt up to skip and tilt down to mark correct. Tilt up or down to start!',
+                        'Hold the phone to your forehead and tilt down or up to start.',
                         style: TextStyle(color: Colors.white, fontSize: 20),
                         textAlign: TextAlign.center,
                       ),


### PR DESCRIPTION
## Summary
- polish end screen layout
- tweak accelerometer tutorial text
- ensure timer keeps running on tilt and vibrate on correct/skip

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e878c2fe883299a49006e00d6b2db