### PR TITLE
Fix tutorial display and cleanup end screen

### DIFF
--- a/lib/screens/game_end_screen.dart
+++ b/lib/screens/game_end_screen.dart
@@ -24,15 +24,6 @@ class GameEndScreen extends StatelessWidget {
       body: Column(
         children: [
           const SizedBox(height: 16),
-          const Text(
-            'Congratulations',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 16),
           Expanded(
             child: ListView.builder(
               itemCount: results.length,
@@ -51,7 +42,6 @@ class GameEndScreen extends StatelessWidget {
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         color: res.correct ? Colors.red : Colors.green,
-                        fontWeight: FontWeight.bold,
                         fontSize: 20,
                       ),
                     ),

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -50,7 +50,10 @@ class _GameScreenState extends State<GameScreen> {
     _currentWord = _remaining.removeLast();
     _timeLeft = GameSettings.roundDuration;
     if (!GameSettings.movementsEnabled) {
-      _accelSub = accelerometerEvents.listen(_onAccelerometer);
+      Future.delayed(const Duration(milliseconds: 500), () {
+        if (!mounted) return;
+        _accelSub = accelerometerEvents.listen(_onAccelerometer);
+      });
     }
     if (!_showInstructions) {
       _startCountdown();


### PR DESCRIPTION
## Summary
- ensure accelerometer listener waits briefly before starting so tutorial screen doesn't disappear immediately
- clean up game end screen by removing duplicate congratulation text and normalizing word styling

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8ae5055c8329823604dfa140f438