### PR TITLE
Adjust UI styles and behavior

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -68,7 +68,7 @@ class _GameScreenState extends State<GameScreen> {
       _showCountdown = true;
     });
     _countdownTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (_countdown == 0) {
+      if (_countdown == 1) {
         timer.cancel();
         setState(() {
           _countdownDisplay = 'Start';
@@ -292,8 +292,7 @@ class _GameScreenState extends State<GameScreen> {
                               ),
                             ),
                           ),
-                          SizedBox(
-                            width: double.infinity,
+                          Align(
                             child: ElevatedButton(
                               style: ElevatedButton.styleFrom(
                                 backgroundColor: Colors.amber[600],
@@ -351,10 +350,13 @@ class _GameScreenState extends State<GameScreen> {
                 Expanded(
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.green,
+                      backgroundColor: Colors.red,
                       padding: const EdgeInsets.symmetric(vertical: 16),
                     ),
-                    onPressed: () => _nextWord(false),
+                    onPressed: () {
+                      HapticFeedback.mediumImpact();
+                      _nextWord(false);
+                    },
                     child: const Text('Skip'),
                   ),
                 ),
@@ -362,10 +364,13 @@ class _GameScreenState extends State<GameScreen> {
                 Expanded(
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.red,
+                      backgroundColor: Colors.green,
                       padding: const EdgeInsets.symmetric(vertical: 16),
                     ),
-                    onPressed: () => _nextWord(true),
+                    onPressed: () {
+                      HapticFeedback.mediumImpact();
+                      _nextWord(true);
+                    },
                     child: const Text('Correct'),
                   ),
                 ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -39,17 +39,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
       backgroundColor: backgroundColor,
       appBar: AppBar(
         backgroundColor: backgroundColor,
-        title: const Text("Settings"),
+        title: const Text(
+          "Settings",
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
         foregroundColor: Colors.white,
         elevation: 0,
       ),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          // 🔹 Settings category
-          const Text("Settings",
-              style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 12),
 
           // Language
           _settingsTile(
@@ -86,7 +85,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // 🔹 Game Settings category
           const Text("Game Settings",
               style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 8),
+          const SizedBox(height: 12),
 
           // Round time (Cupertino Timer Picker)
           _settingsTile(
@@ -201,11 +200,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
             ),
           ),
 
+          const SizedBox(height: 24),
 
           // 🔹 App-Informationen
-          const Text("App Information",
-              style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 8),
+          const Text(
+            "App Information",
+            style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
 
           _infoTile(
             icon: Icons.info_outline,
@@ -299,7 +301,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     required String value,
   }) {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
       decoration: BoxDecoration(
         color: cardColor,
         borderRadius: BorderRadius.circular(16),

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -18,7 +18,10 @@ class TutorialScreen extends StatelessWidget {
         backgroundColor: backgroundColor,
         foregroundColor: Colors.white,
         elevation: 0,
-        title: const Text("How to Play"),
+        title: const Text(
+          "How to Play",
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
       ),
       body: ListView(
         padding: const EdgeInsets.all(20),


### PR DESCRIPTION
## Summary
- refine countdown logic to skip showing `0`
- center the tutorial start button without stretching
- swap Skip/Correct buttons and add haptic feedback
- clean up Settings layout and style section headers consistently
- make AppBar titles bold in Settings and Tutorial screens

## Testing
- `No tests run - Flutter tooling unavailable`

------
https://chatgpt.com/codex/tasks/task_e_687e8fc124788329a440abce359867fc