### PR TITLE
Add dark mode toggle and German/English localization

### DIFF
--- a/lib/game_settings.dart
+++ b/lib/game_settings.dart
@@ -1,12 +1,19 @@
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter/foundation.dart';
 
 class GameSettings {
   static const _durationKey = 'roundDuration';
   static const _movementsKey = 'movementsEnabled';
   static const _tutorialKey = 'startTutorial';
+  static const _darkModeKey = 'darkMode';
+  static const _languageKey = 'languageCode';
   static Duration roundDuration = const Duration(seconds: 60);
   static bool movementsEnabled = false;
   static bool startTutorial = true;
+  static bool darkMode = true;
+  static String languageCode = 'en';
+
+  static final notifier = ValueNotifier<int>(0);
 
   static Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -16,6 +23,8 @@ class GameSettings {
     }
     movementsEnabled = prefs.getBool(_movementsKey) ?? false;
     startTutorial = prefs.getBool(_tutorialKey) ?? true;
+    darkMode = prefs.getBool(_darkModeKey) ?? true;
+    languageCode = prefs.getString(_languageKey) ?? 'en';
   }
 
   static Future<void> save() async {
@@ -23,5 +32,8 @@ class GameSettings {
     await prefs.setInt(_durationKey, roundDuration.inSeconds);
     await prefs.setBool(_movementsKey, movementsEnabled);
     await prefs.setBool(_tutorialKey, startTutorial);
+    await prefs.setBool(_darkModeKey, darkMode);
+    await prefs.setString(_languageKey, languageCode);
+    notifier.value++;
   }
 }

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+class AppLocalizations {
+  final Locale locale;
+  AppLocalizations(this.locale);
+
+  static const supportedLocales = [Locale('en'), Locale('de')];
+
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+
+  static const Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'title': 'Charade',
+      'settings': 'Settings',
+      'languageLabel': 'Language',
+      'languageEnglish': 'English',
+      'languageGerman': 'German',
+      'darkMode': 'Dark Mode',
+      'on': 'On',
+      'off': 'Off',
+      'howToPlay': 'How to Play',
+      'learnRules': 'Learn the rules',
+      'gameSettings': 'Game Settings',
+      'roundTime': 'Round Time',
+      'movements': 'Movements',
+      'movementsDesc': 'Use buttons without gestures',
+      'startTutorial': 'Start tutorial',
+      'startTutorialDesc': 'Show instructions before the game',
+      'appInfo': 'App Information',
+      'appVersion': 'App Version',
+      'rateApp': 'Rate the App',
+      'start': 'Start',
+      'chooseCategory': 'Choose a category',
+      'chooseCategoryDesc': 'Pick one or more categories and set the round time.',
+      'phoneForehead': 'Phone on the forehead',
+      'phoneForeheadDesc': 'Hold the phone to your forehead so your team can read the word.',
+      'tiltControl': 'Tilt to control',
+      'tiltControlDesc': 'Down = correct\nUp = skip',
+      'letsGo': "Let's go!",
+      'haveFun': 'Have fun guessing!',
+      'givePhone': 'Give the phone to another person who marks the words for you.',
+      'holdPhone': 'Hold the phone to your forehead so the display faces the wall.\nThen tilt down or up to start.',
+      'skip': 'Skip',
+      'correct': 'Correct',
+      'congratulations': 'Congratulations',
+      'backToMenu': 'Back to Menu',
+      'enjoyApp': 'Enjoying the app?',
+      'ratePrompt': 'Would you like to rate the app?',
+      'later': 'Later',
+      'rate': 'Rate',
+      'correctCount': '{count} correct',
+      'skippedCount': '{count} skipped'
+    },
+    'de': {
+      'title': 'Charade',
+      'settings': 'Einstellungen',
+      'languageLabel': 'Sprache',
+      'languageEnglish': 'Englisch',
+      'languageGerman': 'Deutsch',
+      'darkMode': 'Dunkler Modus',
+      'on': 'An',
+      'off': 'Aus',
+      'howToPlay': 'Spielanleitung',
+      'learnRules': 'Regeln lernen',
+      'gameSettings': 'Spieleinstellungen',
+      'roundTime': 'Rundenzeit',
+      'movements': 'Bewegungen',
+      'movementsDesc': 'Mit Buttons ohne Gestensteuerung',
+      'startTutorial': 'Tutorial starten',
+      'startTutorialDesc': 'Vor dem Spiel die Erkl\u00e4rung',
+      'appInfo': 'App-Informationen',
+      'appVersion': 'App-Version',
+      'rateApp': 'App bewerten',
+      'start': 'Start',
+      'chooseCategory': 'Kategorie w\u00e4hlen',
+      'chooseCategoryDesc': 'W\u00e4hle eine oder mehrere Kategorien und stelle die Rundenzeit ein.',
+      'phoneForehead': 'Handy an die Stirn',
+      'phoneForeheadDesc': 'Halte das Handy an deine Stirn, damit dein Team das Wort lesen kann.',
+      'tiltControl': 'Kippen zur Steuerung',
+      'tiltControlDesc': 'Unten = richtig\nOben = \u00fcberspringen',
+      'letsGo': 'Los geht\u2019s!',
+      'haveFun': 'Viel Spa\u00df beim Raten!',
+      'givePhone': 'Gib das Handy einer anderen Person, die die W\u00f6rter f\u00fcr dich markiert.',
+      'holdPhone': 'Halte das Handy an deine Stirn, sodass das Display zur Wand zeigt.\nKippe dann nach unten oder oben, um zu starten.',
+      'skip': 'Weiter',
+      'correct': 'Richtig',
+      'congratulations': 'Gl\u00fcckwunsch',
+      'backToMenu': 'Zur\u00fcck zum Men\u00fc',
+      'enjoyApp': 'Gef\u00e4llt dir die App?',
+      'ratePrompt': 'M\u00f6chtest du die App bewerten?',
+      'later': 'Sp\u00e4ter',
+      'rate': 'Bewerten',
+      'correctCount': '{count} richtig',
+      'skippedCount': '{count} \u00fcbersprungen'
+    }
+  };
+
+  String t(String key, {Map<String, String>? params}) {
+    var str = _localizedValues[locale.languageCode]?[key] ?? key;
+    params?.forEach((k, v) {
+      str = str.replaceAll('{$k}', v);
+    });
+    return str;
+  }
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+}
+
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+  @override
+  bool isSupported(Locale locale) => ['en', 'de'].contains(locale.languageCode);
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    return AppLocalizations(locale);
+  }
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'game_settings.dart';
 import 'notification_service.dart';
+import 'localization.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,11 +18,26 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Media Grid UI',
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData.dark(),
-      home: const HomeScreen(),
+    return ValueListenableBuilder<int>(
+      valueListenable: GameSettings.notifier,
+      builder: (context, _, __) {
+        return MaterialApp(
+          title: 'Charade',
+          debugShowCheckedModeBanner: false,
+          theme: ThemeData.light(),
+          darkTheme: ThemeData.dark(),
+          themeMode: GameSettings.darkMode ? ThemeMode.dark : ThemeMode.light,
+          locale: Locale(GameSettings.languageCode),
+          supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          home: const HomeScreen(),
+        );
+      },
     );
   }
 }

--- a/lib/screens/game_end_screen.dart
+++ b/lib/screens/game_end_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:in_app_review/in_app_review.dart';
+import '../localization.dart';
 
 import 'game_screen.dart';
 
@@ -45,16 +46,16 @@ class _GameEndScreenState extends State<GameEndScreen> {
         final result = await showDialog<bool>(
           context: context,
           builder: (context) => AlertDialog(
-            title: const Text('Enjoying the app?'),
-            content: const Text('Would you like to rate the app?'),
+            title: Text(AppLocalizations.of(context).t('enjoyApp')),
+            content: Text(AppLocalizations.of(context).t('ratePrompt')),
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context, false),
-                child: const Text('Later'),
+                child: Text(AppLocalizations.of(context).t('later')),
               ),
               TextButton(
                 onPressed: () => Navigator.pop(context, true),
-                child: const Text('Rate'),
+                child: Text(AppLocalizations.of(context).t('rate')),
               ),
             ],
           ),
@@ -85,13 +86,13 @@ class _GameEndScreenState extends State<GameEndScreen> {
       DeviceOrientation.portraitUp,
     ]);
     return Scaffold(
-      backgroundColor: const Color(0xFF0F0F1C),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
-        title: const Text(
-          'Congratulations',
-          style: TextStyle(fontWeight: FontWeight.bold),
+        title: Text(
+          AppLocalizations.of(context).t('congratulations'),
+          style: const TextStyle(fontWeight: FontWeight.bold),
         ),
-        backgroundColor: const Color(0xFF0F0F1C),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       ),
       body: Column(
         children: [
@@ -130,7 +131,8 @@ class _GameEndScreenState extends State<GameEndScreen> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
-                  '$_correctCount correct',
+                  AppLocalizations.of(context)
+                      .t('correctCount', params: {'count': '$_correctCount'}),
                   style: const TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,
@@ -139,7 +141,8 @@ class _GameEndScreenState extends State<GameEndScreen> {
                 ),
                 const SizedBox(width: 24),
                 Text(
-                  '$_skippedCount skipped',
+                  AppLocalizations.of(context)
+                      .t('skippedCount', params: {'count': '$_skippedCount'}),
                   style: const TextStyle(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,
@@ -162,9 +165,9 @@ class _GameEndScreenState extends State<GameEndScreen> {
                   ),
                 ),
                 onPressed: () => Navigator.pop(context),
-                child: const Text(
-                  'Back to Menu',
-                  style: TextStyle(
+                child: Text(
+                  AppLocalizations.of(context).t('backToMenu'),
+                  style: const TextStyle(
                     color: Colors.black,
                     fontWeight: FontWeight.bold,
                   ),

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -6,6 +6,7 @@ import 'package:sensors_plus/sensors_plus.dart';
 
 import '../game_settings.dart';
 import 'game_end_screen.dart';
+import '../localization.dart';
 import 'package:flutter/services.dart';
 
 class GameScreen extends StatefulWidget {
@@ -37,12 +38,15 @@ class _GameScreenState extends State<GameScreen> {
   bool _tiltCorrect = false;
   bool _readyForTilt = false;
   Color _background = const Color(0xFF0F0F1C);
+
+  Color get _baseBackground => Theme.of(context).scaffoldBackgroundColor;
   final List<WordResult> _results = [];
   static const int _maxDots = 8;
 
   @override
   void initState() {
     super.initState();
+    _background = _baseBackground;
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeRight,
     ]);
@@ -76,7 +80,7 @@ class _GameScreenState extends State<GameScreen> {
           HapticFeedback.heavyImpact();
         });
         setState(() {
-          _countdownDisplay = 'Start';
+          _countdownDisplay = AppLocalizations.of(context).t('start');
         });
         Future.delayed(const Duration(seconds: 1), () {
           if (!mounted) return;
@@ -195,7 +199,7 @@ class _GameScreenState extends State<GameScreen> {
     Future.delayed(const Duration(milliseconds: 300), () {
       if (!mounted) return;
       setState(() {
-        _background = const Color(0xFF0F0F1C);
+        _background = _baseBackground;
         _currentWord = _remaining.removeLast();
       });
     });
@@ -317,9 +321,9 @@ class _GameScreenState extends State<GameScreen> {
                         children: [
                           Expanded(
                             child: Center(
-                              child: const Text(
-                                'Give the phone to another person who marks the words for you.',
-                                style: TextStyle(
+                              child: Text(
+                                AppLocalizations.of(context).t('givePhone'),
+                                style: const TextStyle(
                                     color: Colors.white, fontSize: 24),
                                 textAlign: TextAlign.center,
                               ),
@@ -335,9 +339,9 @@ class _GameScreenState extends State<GameScreen> {
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 40),
                               ),
                               onPressed: _startGame,
-                              child: const Text(
-                                'Start',
-                                style: TextStyle(
+                              child: Text(
+                                AppLocalizations.of(context).t('start'),
+                                style: const TextStyle(
                                   color: Colors.black,
                                   fontWeight: FontWeight.bold,
                                   fontSize: 20,
@@ -347,9 +351,9 @@ class _GameScreenState extends State<GameScreen> {
                           ),
                         ],
                       )
-                    : const Text(
-                        'Hold the phone to your forehead so the display faces the wall.\nThen tilt down or up to start.',
-                        style: TextStyle(color: Colors.white, fontSize: 20),
+                    : Text(
+                        AppLocalizations.of(context).t('holdPhone'),
+                        style: const TextStyle(color: Colors.white, fontSize: 20),
                         textAlign: TextAlign.center,
                       ),
               ),
@@ -389,7 +393,7 @@ class _GameScreenState extends State<GameScreen> {
                       HapticFeedback.mediumImpact();
                       _nextWord(false);
                     },
-                    child: const Text('Skip'),
+                    child: Text(AppLocalizations.of(context).t('skip')),
                   ),
                 ),
                 const SizedBox(width: 20),
@@ -403,7 +407,7 @@ class _GameScreenState extends State<GameScreen> {
                       HapticFeedback.mediumImpact();
                       _nextWord(true);
                     },
-                    child: const Text('Correct'),
+                    child: Text(AppLocalizations.of(context).t('correct')),
                   ),
                 ),
               ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:charadex/screens/game_screen.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import '../game_settings.dart';
+import '../localization.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -14,9 +15,9 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  final backgroundColor = const Color(0xFF0F0F1C);
-  final cardColor = const Color(0xFF1E1E2D);
-  final Color highlightColor = Colors.purple;
+  Color get backgroundColor => Theme.of(context).scaffoldBackgroundColor;
+  Color get cardColor => Theme.of(context).cardColor;
+  Color get highlightColor => Theme.of(context).colorScheme.primary;
 
   String selectedMenuId = "all";
   final Set<String> selectedImageIds = {};
@@ -48,9 +49,9 @@ class _HomeScreenState extends State<HomeScreen> {
           },
         ),
         centerTitle: true,
-        title: const Text(
-          'Charade',
-          style: TextStyle(
+        title: Text(
+          AppLocalizations.of(context).t('title'),
+          style: const TextStyle(
             color: Colors.white,
             fontWeight: FontWeight.bold,
           ),
@@ -215,9 +216,9 @@ class _HomeScreenState extends State<HomeScreen> {
                       ),
                     );
                   },
-                  label: const Text(
-                    "Start",
-                    style: TextStyle(
+                  label: Text(
+                    AppLocalizations.of(context).t('start'),
+                    style: const TextStyle(
                       color: Colors.black,
                       fontWeight: FontWeight.bold,
                     ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:in_app_review/in_app_review.dart';
 import 'package:flutter/services.dart';
 import '../game_settings.dart';
+import '../localization.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -13,14 +14,15 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  String _selectedLanguage = 'English';
+  String _selectedLanguage = GameSettings.languageCode;
   Duration _selectedDuration = GameSettings.roundDuration;
   bool _movements = GameSettings.movementsEnabled;
   bool _startTutorial = GameSettings.startTutorial;
+  bool _darkMode = GameSettings.darkMode;
 
-  final backgroundColor = const Color(0xFF0F0F1C);
-  final cardColor = const Color(0xFF1E1E2D);
-  final purple = const Color(0xFF9B5EFF);
+  Color get backgroundColor => Theme.of(context).scaffoldBackgroundColor;
+  Color get cardColor => Theme.of(context).cardColor;
+  Color get purple => Theme.of(context).colorScheme.primary;
 
   @override
   void initState() {
@@ -39,9 +41,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
       backgroundColor: backgroundColor,
       appBar: AppBar(
         backgroundColor: backgroundColor,
-        title: const Text(
-          "Settings",
-          style: TextStyle(fontWeight: FontWeight.bold),
+        title: Text(
+          AppLocalizations.of(context).t('settings'),
+          style: const TextStyle(fontWeight: FontWeight.bold),
         ),
         foregroundColor: Colors.white,
         elevation: 0,
@@ -53,14 +55,54 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // Language
           _settingsTile(
             icon: Icons.language,
-            title: "Language",
-            value: _selectedLanguage,
+            title: AppLocalizations.of(context).t('languageLabel'),
+            value: _selectedLanguage == 'en'
+                ? AppLocalizations.of(context).t('languageEnglish')
+                : AppLocalizations.of(context).t('languageGerman'),
             onTap: () {
               setState(() {
-                _selectedLanguage =
-                    _selectedLanguage == 'English' ? 'German' : 'English';
+                _selectedLanguage = _selectedLanguage == 'en' ? 'de' : 'en';
+                GameSettings.languageCode = _selectedLanguage;
               });
+              GameSettings.save();
             },
+          ),
+
+          const SizedBox(height: 12),
+
+          // Dark mode toggle
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+            decoration: BoxDecoration(
+              color: cardColor,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.brightness_6, color: Colors.amber[600]),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Text(
+                    AppLocalizations.of(context).t('darkMode'),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: _darkMode,
+                  activeColor: Colors.amber,
+                  onChanged: (val) {
+                    setState(() {
+                      _darkMode = val;
+                      GameSettings.darkMode = val;
+                    });
+                    GameSettings.save();
+                  },
+                ),
+              ],
+            ),
           ),
 
           const SizedBox(height: 12),
@@ -68,8 +110,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
           // Tutorial-Link
           _settingsTile(
             icon: Icons.menu_book,
-            title: "How to Play",
-            value: "Learn the rules",
+            title: AppLocalizations.of(context).t('howToPlay'),
+            value: AppLocalizations.of(context).t('learnRules'),
             onTap: () {
               Navigator.push(
                 context,
@@ -82,15 +124,14 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
           const SizedBox(height: 24),
 
-          // 🔹 Game Settings category
-          const Text("Game Settings",
-              style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
+          Text(AppLocalizations.of(context).t('gameSettings'),
+              style: const TextStyle(color: Colors.white70, fontWeight: FontWeight.bold)),
           const SizedBox(height: 12),
 
           // Round time (Cupertino Timer Picker)
           _settingsTile(
             icon: Icons.timer,
-            title: "Round Time",
+            title: AppLocalizations.of(context).t('roundTime'),
             value: _formatDuration(_selectedDuration),
             onTap: () {
               showModalBottomSheet(
@@ -139,12 +180,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: [
                 Icon(Icons.directions_run, color: Colors.amber[600]),
                 const SizedBox(width: 16),
-                const Expanded(
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Movements',
+                        AppLocalizations.of(context).t('movements'),
                         style: TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.bold,
@@ -152,7 +193,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ),
                       SizedBox(height: 4),
                       Text(
-                        'Mit Buttons ohne Gestensteuerung',
+                        AppLocalizations.of(context).t('movementsDesc'),
                         style: TextStyle(color: Colors.white70, fontSize: 12),
                       ),
                     ],
@@ -186,12 +227,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: [
                 Icon(Icons.play_circle_outline, color: Colors.amber[600]),
                 const SizedBox(width: 16),
-                const Expanded(
+                Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'Start tutorial',
+                        AppLocalizations.of(context).t('startTutorial'),
                         style: TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.bold,
@@ -199,7 +240,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ),
                       SizedBox(height: 4),
                       Text(
-                        'Vor dem Spiel die Erkl\u00e4rung',
+                        AppLocalizations.of(context).t('startTutorialDesc'),
                         style: TextStyle(color: Colors.white70, fontSize: 12),
                       ),
                     ],
@@ -223,15 +264,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const SizedBox(height: 24),
 
           // 🔹 App-Informationen
-          const Text(
-            "App Information",
-            style: TextStyle(color: Colors.white70, fontWeight: FontWeight.bold),
+          Text(
+            AppLocalizations.of(context).t('appInfo'),
+            style: const TextStyle(color: Colors.white70, fontWeight: FontWeight.bold),
           ),
           const SizedBox(height: 12),
 
           _infoTile(
             icon: Icons.info_outline,
-            title: "App Version",
+            title: AppLocalizations.of(context).t('appVersion'),
             value: "1.1.0",
           ),
 
@@ -256,10 +297,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 children: [
                   Icon(Icons.star_rate, color: Colors.amber[600]),
                   const SizedBox(width: 16),
-                  const Expanded(
+                  Expanded(
                     child: Text(
-                      "Rate the App",
-                      style: TextStyle(
+                      AppLocalizations.of(context).t('rateApp'),
+                      style: const TextStyle(
                         color: Colors.white,
                         fontWeight: FontWeight.bold,
                       ),

--- a/lib/screens/tutorial.dart
+++ b/lib/screens/tutorial.dart
@@ -4,23 +4,22 @@ import 'package:flutter/services.dart';
 class TutorialScreen extends StatelessWidget {
   const TutorialScreen({super.key});
 
-  final backgroundColor = const Color(0xFF0F0F1C);
-  final cardColor = const Color(0xFF1E1E2D);
-
   @override
   Widget build(BuildContext context) {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
     ]);
+    final bg = Theme.of(context).scaffoldBackgroundColor;
+    final cardColor = Theme.of(context).cardColor;
     return Scaffold(
-      backgroundColor: backgroundColor,
+      backgroundColor: bg,
       appBar: AppBar(
-        backgroundColor: backgroundColor,
+        backgroundColor: bg,
         foregroundColor: Colors.white,
         elevation: 0,
-        title: const Text(
-          "How to Play",
-          style: TextStyle(fontWeight: FontWeight.bold),
+        title: Text(
+          AppLocalizations.of(context).t('howToPlay'),
+          style: const TextStyle(fontWeight: FontWeight.bold),
         ),
       ),
       body: ListView(
@@ -28,22 +27,25 @@ class TutorialScreen extends StatelessWidget {
         children: [
           _tutorialBox(
             step: 1,
-            heading: "Choose a category",
+            cardColor: cardColor,
+            heading: AppLocalizations.of(context).t('chooseCategory'),
             description:
-                "Pick one or more categories and set the round time.",
+                AppLocalizations.of(context).t('chooseCategoryDesc'),
           ),
           const SizedBox(height: 16),
           _tutorialBox(
             step: 2,
-            heading: "Phone on the forehead",
+            cardColor: cardColor,
+            heading: AppLocalizations.of(context).t('phoneForehead'),
             description:
-                "Hold the phone to your forehead so your team can read the word.",
+                AppLocalizations.of(context).t('phoneForeheadDesc'),
           ),
           const SizedBox(height: 16),
           _tutorialBox(
             step: 3,
-            heading: "Tilt to control",
-            description: "Down = correct\nUp = skip",
+            cardColor: cardColor,
+            heading: AppLocalizations.of(context).t('tiltControl'),
+            description: AppLocalizations.of(context).t('tiltControlDesc'),
             extras: [
               const SizedBox(height: 12),
               Row(
@@ -68,8 +70,9 @@ class TutorialScreen extends StatelessWidget {
           const SizedBox(height: 16),
           _tutorialBox(
             step: 4,
-            heading: "Let's go!",
-            description: "Have fun guessing!",
+            cardColor: cardColor,
+            heading: AppLocalizations.of(context).t('letsGo'),
+            description: AppLocalizations.of(context).t('haveFun'),
           ),
         ],
       ),
@@ -80,6 +83,7 @@ class TutorialScreen extends StatelessWidget {
     required int step,
     required String heading,
     required String description,
+    required Color cardColor,
     List<Widget> extras = const [],
   }) {
     return Container(


### PR DESCRIPTION
## Summary
- add simple localization system with German and English strings
- store language and dark mode settings
- update main app to listen for settings changes and switch theme and locale
- translate UI texts in home, settings, tutorial, game and results screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ea3886b108329886fd6b61a8e86e3