### PR TITLE
Disable unused localization generation

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,0 @@
-l10n:
-  arb-dir: lib/l10n
-  template-arb-file: app_en.arb
-  output-localization-file: app_localizations.dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   # aktiviert Code-Gen für die ARB-Dateien
-  generate: true
+  generate: false
 
   assets:
     - assets/topics/animals.png


### PR DESCRIPTION
## Summary
- delete stale `l10n.yaml`
- turn off automatic localization generation in `pubspec.yaml`

This prevents Flutter from trying to generate localization files when the ARB directory doesn't exist.

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eaf8b06fc8329875a8e98ebe4b2cf