### PR TITLE
Fix result colors and add new categories

### DIFF
--- a/assets/words/de.json
+++ b/assets/words/de.json
@@ -145,5 +145,54 @@
     "membership",
     "series",
     "movies"
+  ],
+  "brands": [
+    "Nike",
+    "Adidas",
+    "Apple",
+    "Samsung",
+    "Coca Cola"
+  ],
+  "capitals": [
+    "Berlin",
+    "London",
+    "Paris",
+    "Rome",
+    "Tokyo"
+  ],
+  "christmas": [
+    "Santa",
+    "Reindeer",
+    "Snow",
+    "Tree",
+    "Gifts"
+  ],
+  "stars": [
+    "Sun",
+    "Polaris",
+    "Sirius",
+    "Betelgeuse",
+    "Rigel"
+  ],
+  "intoxicants": [
+    "alcohol",
+    "weed",
+    "cigarettes",
+    "cocaine",
+    "morphine"
+  ],
+  "games": [
+    "chess",
+    "poker",
+    "soccer",
+    "monopoly",
+    "fortnite"
+  ],
+  "food": [
+    "pizza",
+    "burger",
+    "pasta",
+    "salad",
+    "sushi"
   ]
 }

--- a/assets/words/en.json
+++ b/assets/words/en.json
@@ -145,5 +145,54 @@
     "membership",
     "series",
     "movies"
+  ],
+  "brands": [
+    "Nike",
+    "Adidas",
+    "Apple",
+    "Samsung",
+    "Coca Cola"
+  ],
+  "capitals": [
+    "Berlin",
+    "London",
+    "Paris",
+    "Rome",
+    "Tokyo"
+  ],
+  "christmas": [
+    "Santa",
+    "Reindeer",
+    "Snow",
+    "Tree",
+    "Gifts"
+  ],
+  "stars": [
+    "Sun",
+    "Polaris",
+    "Sirius",
+    "Betelgeuse",
+    "Rigel"
+  ],
+  "intoxicants": [
+    "alcohol",
+    "weed",
+    "cigarettes",
+    "cocaine",
+    "morphine"
+  ],
+  "games": [
+    "chess",
+    "poker",
+    "soccer",
+    "monopoly",
+    "fortnite"
+  ],
+  "food": [
+    "pizza",
+    "burger",
+    "pasta",
+    "salad",
+    "sushi"
   ]
 }

--- a/assets/words/es.json
+++ b/assets/words/es.json
@@ -145,5 +145,54 @@
     "membership",
     "series",
     "movies"
+  ],
+  "brands": [
+    "Nike",
+    "Adidas",
+    "Apple",
+    "Samsung",
+    "Coca Cola"
+  ],
+  "capitals": [
+    "Berlin",
+    "London",
+    "Paris",
+    "Rome",
+    "Tokyo"
+  ],
+  "christmas": [
+    "Santa",
+    "Reindeer",
+    "Snow",
+    "Tree",
+    "Gifts"
+  ],
+  "stars": [
+    "Sun",
+    "Polaris",
+    "Sirius",
+    "Betelgeuse",
+    "Rigel"
+  ],
+  "intoxicants": [
+    "alcohol",
+    "weed",
+    "cigarettes",
+    "cocaine",
+    "morphine"
+  ],
+  "games": [
+    "chess",
+    "poker",
+    "soccer",
+    "monopoly",
+    "fortnite"
+  ],
+  "food": [
+    "pizza",
+    "burger",
+    "pasta",
+    "salad",
+    "sushi"
   ]
 }

--- a/assets/words/fr.json
+++ b/assets/words/fr.json
@@ -145,5 +145,54 @@
     "membership",
     "series",
     "movies"
+  ],
+  "brands": [
+    "Nike",
+    "Adidas",
+    "Apple",
+    "Samsung",
+    "Coca Cola"
+  ],
+  "capitals": [
+    "Berlin",
+    "London",
+    "Paris",
+    "Rome",
+    "Tokyo"
+  ],
+  "christmas": [
+    "Santa",
+    "Reindeer",
+    "Snow",
+    "Tree",
+    "Gifts"
+  ],
+  "stars": [
+    "Sun",
+    "Polaris",
+    "Sirius",
+    "Betelgeuse",
+    "Rigel"
+  ],
+  "intoxicants": [
+    "alcohol",
+    "weed",
+    "cigarettes",
+    "cocaine",
+    "morphine"
+  ],
+  "games": [
+    "chess",
+    "poker",
+    "soccer",
+    "monopoly",
+    "fortnite"
+  ],
+  "food": [
+    "pizza",
+    "burger",
+    "pasta",
+    "salad",
+    "sushi"
   ]
 }

--- a/assets/words/hr.json
+++ b/assets/words/hr.json
@@ -145,5 +145,54 @@
     "membership",
     "series",
     "movies"
+  ],
+  "brands": [
+    "Nike",
+    "Adidas",
+    "Apple",
+    "Samsung",
+    "Coca Cola"
+  ],
+  "capitals": [
+    "Berlin",
+    "London",
+    "Paris",
+    "Rome",
+    "Tokyo"
+  ],
+  "christmas": [
+    "Santa",
+    "Reindeer",
+    "Snow",
+    "Tree",
+    "Gifts"
+  ],
+  "stars": [
+    "Sun",
+    "Polaris",
+    "Sirius",
+    "Betelgeuse",
+    "Rigel"
+  ],
+  "intoxicants": [
+    "alcohol",
+    "weed",
+    "cigarettes",
+    "cocaine",
+    "morphine"
+  ],
+  "games": [
+    "chess",
+    "poker",
+    "soccer",
+    "monopoly",
+    "fortnite"
+  ],
+  "food": [
+    "pizza",
+    "burger",
+    "pasta",
+    "salad",
+    "sushi"
   ]
 }

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -163,4 +163,46 @@ const List<Map<String, dynamic>> imageItems = [
     "fitMenuItemIds": ["films"],
     "imagePath": "assets/topics/films/prime.jpeg",
   },
+  {
+    "id": "brands",
+    "label": "Brands",
+    "fitMenuItemIds": ["kids"],
+    "imagePath": "assets/topics/brands.jpeg",
+  },
+  {
+    "id": "capitals",
+    "label": "Capitals",
+    "fitMenuItemIds": ["kids"],
+    "imagePath": "assets/topics/capitals.jpeg",
+  },
+  {
+    "id": "christmas",
+    "label": "Christmas",
+    "fitMenuItemIds": ["kids"],
+    "imagePath": "assets/topics/christmas.jpeg",
+  },
+  {
+    "id": "stars",
+    "label": "Stars",
+    "fitMenuItemIds": ["films"],
+    "imagePath": "assets/topics/stars.jpeg",
+  },
+  {
+    "id": "intoxicants",
+    "label": "Intoxicants",
+    "fitMenuItemIds": ["adult"],
+    "imagePath": "assets/topics/intoxicants.jpeg",
+  },
+  {
+    "id": "games",
+    "label": "Games",
+    "fitMenuItemIds": ["kids"],
+    "imagePath": "assets/topics/games.jpeg",
+  },
+  {
+    "id": "food",
+    "label": "Food",
+    "fitMenuItemIds": ["kids"],
+    "imagePath": "assets/topics/food.jpeg",
+  },
 ];

--- a/lib/screens/game_end_screen.dart
+++ b/lib/screens/game_end_screen.dart
@@ -90,7 +90,7 @@ class _GameEndScreenState extends State<GameEndScreen> {
                       style: TextStyle(
                         color: res.correct == null
                             ? Colors.grey
-                            : (res.correct! ? Colors.red : Colors.green),
+                            : (res.correct! ? Colors.green : Colors.red),
                         fontSize: 20,
                       ),
                     ),

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -173,7 +173,7 @@ class _GameScreenState extends State<GameScreen> {
                 size: 10,
                 color: r.correct == null
                     ? Colors.grey
-                    : (r.correct! ? Colors.red : Colors.green),
+                    : (r.correct! ? Colors.green : Colors.red),
               ),
             ),
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,16 +55,16 @@ flutter:
     - assets/topics/films/netflix.jpeg
     - assets/topics/films/paramount.jpeg
     - assets/topics/films/prime.jpeg
+    - assets/topics/brands.jpeg
+    - assets/topics/capitals.jpeg
+    - assets/topics/christmas.jpeg
+    - assets/topics/stars.jpeg
+    - assets/topics/intoxicants.jpeg
+    - assets/topics/games.jpeg
+    - assets/topics/food.jpeg
     - assets/tutorial/incorrect.png
     - assets/tutorial/correct.png
     - assets/tutorial/tutorial.png
-    - assets/tutorial/brands.jpeg
-    - assets/tutorial/capitals.jpeg
-    - assets/tutorial/christmas.jpeg
-    - assets/tutorial/stars.jpeg
-    - assets/tutorial/intoxicants.jpeg
-    - assets/tutorial/games.jpeg
-    - assets/tutorial/food.jpeg
     - assets/words/en.json
     - assets/words/de.json
     - assets/words/es.json


### PR DESCRIPTION
## Summary
- correct words now show green indicators while skipped words show red
- include new categories with assets and word lists
- update pubspec asset paths

## Testing
- `dart format lib/screens/game_screen.dart lib/screens/game_end_screen.dart lib/data.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687ffa82d7c0832999c203cd33cf2c2c