### PR TITLE
Fix localization JSON parsing error

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -41,7 +41,7 @@
   "later": "Später",
   "rate": "Bewerten",
   "correctCount": "{count} richtig",
-  "skippedCount": "{count} übersprungen"
+  "skippedCount": "{count} übersprungen",
 
   "menu_all": "Alle",
   "menu_kids": "Kinder",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -41,7 +41,7 @@
   "later": "Más tarde",
   "rate": "Calificar",
   "correctCount": "{count} correctas",
-  "skippedCount": "{count} omitidas"
+  "skippedCount": "{count} omitidas",
 
   "menu_all": "Todo",
   "menu_kids": "Niños",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -41,7 +41,7 @@
   "later": "Plus tard",
   "rate": "Noter",
   "correctCount": "{count} correct",
-  "skippedCount": "{count} passé"
+  "skippedCount": "{count} passé",
 
   "menu_all": "Tout",
   "menu_kids": "Enfants",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -41,7 +41,7 @@
   "later": "Kasnije",
   "rate": "Ocijeni",
   "correctCount": "{count} točno",
-  "skippedCount": "{count} preskočeno"
+  "skippedCount": "{count} preskočeno",
 
   "menu_all": "Sve",
   "menu_kids": "Djeca",


### PR DESCRIPTION
## Summary
- add missing commas after `skippedCount` entries in non-English ARB files

## Testing
- `python3 - <<'EOF'
import json
for f in ['lib/l10n/app_de.arb','lib/l10n/app_es.arb','lib/l10n/app_fr.arb','lib/l10n/app_hr.arb','lib/l10n/app_en.arb']:
    try:
        json.load(open(f))
        print(f, 'ok')
    except Exception as e:
        print(f, e)
EOF`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68800463c1fc8329949cf1bc5e0284b6