### PR TITLE
Fix tilt color and early exit

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -133,14 +133,14 @@ class _GameScreenState extends State<GameScreen> {
     if (!_processingTilt) {
       if (z > 7) {
         _processingTilt = true;
-        _tiltCorrect = true;
+        _tiltCorrect = false;
         setState(() {
           _background = Colors.red;
         });
         HapticFeedback.mediumImpact();
       } else if (z < -7) {
         _processingTilt = true;
-        _tiltCorrect = false;
+        _tiltCorrect = true;
         setState(() {
           _background = Colors.green;
         });
@@ -255,7 +255,13 @@ class _GameScreenState extends State<GameScreen> {
               top: 8,
               left: 8,
               child: GestureDetector(
-                onTap: () => _endRound(addUnanswered: true),
+                onTap: () {
+                  if (_showInstructions || _showCountdown) {
+                    Navigator.pop(context);
+                  } else {
+                    _endRound(addUnanswered: true);
+                  }
+                },
                 child: Container(
                   width: 48,
                   height: 48,


### PR DESCRIPTION
## Summary
- fix tilt results to prevent incorrect color flash
- exit to home when closing before first word

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68800fbe1f7c8329b0af5b6d1c96fe51