### PR TITLE
Add education filter and progress for tilt mode

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -32,6 +32,12 @@ const List<Map<String, dynamic>> menuItems = [
     "titleKey": "menu_films",
     "isSelected": false,
   },
+  {
+    "id": "education",
+    "name": "Education",
+    "titleKey": "menu_education",
+    "isSelected": false,
+  },
 ];
 
 /// Bildthemen mit ID, Titel-Schlüssel für Übersetzung,
@@ -46,25 +52,25 @@ const List<Map<String, dynamic>> imageItems = [
   {
     "id": "history",
     "label": "History",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/history.png",
   },
   {
     "id": "geography",
     "label": "Geography",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/geography.png",
   },
   {
     "id": "countries",
     "label": "Countries",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/countries.jpeg",
   },
   {
     "id": "capitals",
     "label": "Capitals",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/capitals.jpeg",
   },
   {
@@ -94,13 +100,13 @@ const List<Map<String, dynamic>> imageItems = [
   {
     "id": "animals",
     "label": "Animals",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/animals.png",
   },
   {
     "id": "jobs",
     "label": "Jobs",
-    "fitMenuItemIds": ["kids"],
+    "fitMenuItemIds": ["kids", "education"],
     "imagePath": "assets/topics/jobs.png",
   },
   {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -48,6 +48,7 @@
   "menu_sport": "Sport",
   "menu_adult": "18+",
   "menu_films": "Filme",
+  "menu_education": "Bildung",
   "category_animals": "Tiere",
   "category_basketball": "Basketball",
   "category_cars": "Autos",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,6 +48,7 @@
   "menu_sport": "Sport",
   "menu_adult": "18+",
   "menu_films": "Films",
+  "menu_education": "Education",
   "category_animals": "Animals",
   "category_basketball": "Basketball",
   "category_cars": "Cars",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -48,6 +48,7 @@
   "menu_sport": "Deporte",
   "menu_adult": "18+",
   "menu_films": "Películas",
+  "menu_education": "Educación",
   "category_animals": "Animales",
   "category_basketball": "Baloncesto",
   "category_cars": "Autos",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -48,6 +48,7 @@
   "menu_sport": "Sport",
   "menu_adult": "18+",
   "menu_films": "Films",
+  "menu_education": "Éducation",
   "category_animals": "Animaux",
   "category_basketball": "Basketball",
   "category_cars": "Voitures",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -48,6 +48,7 @@
   "menu_sport": "Sport",
   "menu_adult": "18+",
   "menu_films": "Filmovi",
+  "menu_education": "Obrazovanje",
   "category_animals": "Životinje",
   "category_basketball": "Košarka",
   "category_cars": "Automobili",

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -374,63 +374,70 @@ class _GameScreenState extends State<GameScreen> {
           ],
         ),
       ),
-      bottomNavigationBar: _showCountdown || _showInstructions || !GameSettings.movementsEnabled
+      bottomNavigationBar: _showCountdown || _showInstructions
           ? null
           : Padding(
               padding: const EdgeInsets.all(20),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-            if (_results.isNotEmpty)
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: Colors.black,
-                  borderRadius: BorderRadius.circular(10),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.min,
-                  children: _buildDots(),
-                ),
+                  if (_results.isNotEmpty)
+                    Container(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.black,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: _buildDots(),
+                      ),
+                    ),
+                  if (_results.isNotEmpty && GameSettings.movementsEnabled)
+                    const SizedBox(height: 10),
+                  if (GameSettings.movementsEnabled)
+                    Row(
+                      children: [
+                        Expanded(
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.red,
+                              foregroundColor: Colors.white,
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 16),
+                            ),
+                            onPressed: () {
+                              HapticFeedback.mediumImpact();
+                              _nextWord(false);
+                            },
+                            child:
+                                Text(AppLocalizations.of(context).t('skip')),
+                          ),
+                        ),
+                        const SizedBox(width: 20),
+                        Expanded(
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.green,
+                              foregroundColor: Colors.white,
+                              padding:
+                                  const EdgeInsets.symmetric(vertical: 16),
+                            ),
+                            onPressed: () {
+                              HapticFeedback.mediumImpact();
+                              _nextWord(true);
+                            },
+                            child:
+                                Text(AppLocalizations.of(context).t('correct')),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
               ),
-            if (_results.isNotEmpty) const SizedBox(height: 10),
-            Row(
-              children: [
-                Expanded(
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.red,
-                      foregroundColor: Colors.white,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                    ),
-                    onPressed: () {
-                      HapticFeedback.mediumImpact();
-                      _nextWord(false);
-                    },
-                    child: Text(AppLocalizations.of(context).t('skip')),
-                  ),
-                ),
-                const SizedBox(width: 20),
-                Expanded(
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.green,
-                      foregroundColor: Colors.white,
-                      padding: const EdgeInsets.symmetric(vertical: 16),
-                    ),
-                    onPressed: () {
-                      HapticFeedback.mediumImpact();
-                      _nextWord(true);
-                    },
-                    child: Text(AppLocalizations.of(context).t('correct')),
-                  ),
-                ),
-              ],
             ),
-          ],
-        ),
-      ),
     ),
     );
   }


### PR DESCRIPTION
## Summary
- add a new "education" filter and translations
- display dots progress even when phone movement is used
- assign education categories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881564365688329aa3f4d349a25efb5