### PR TITLE
Fix tutorial image row overflow

### DIFF
--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -381,19 +381,30 @@ class _GameScreenState extends State<GameScreen> {
                             ),
                           ),
                           Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
-                              Image.asset(
-                                'assets/tutorial/incorrect.png',
-                                height: 80,
+                              Expanded(
+                                child: Image.asset(
+                                  'assets/tutorial/incorrect.png',
+                                  height: 80,
+                                ),
                               ),
-                              Image.asset(
-                                'assets/tutorial/tutorial.png',
-                                height: 80,
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(12),
+                                  child: Image.asset(
+                                    'assets/tutorial/tutorial.png',
+                                    height: 80,
+                                    fit: BoxFit.cover,
+                                  ),
+                                ),
                               ),
-                              Image.asset(
-                                'assets/tutorial/correct.png',
-                                height: 80,
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Image.asset(
+                                  'assets/tutorial/correct.png',
+                                  height: 80,
+                                ),
                               ),
                             ],
                           ),


### PR DESCRIPTION
## Summary
- avoid overflow in instructions row on `GameScreen`
- give the center tutorial image rounded corners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815c90222c8329a7b7197dfef7e56d