### PR TITLE
Fix link launching in home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -9,6 +9,7 @@ import '../localization.dart';
 import '../words.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -380,7 +381,7 @@ class _HomeScreenState extends State<HomeScreen> {
     return GestureDetector(
       onTap: () {
         launchUrlString(
-          'https://apps.apple.com/app/apple-store/id6745120053?pt=126797007&ct=PartyBomb&mt=8',
+          'https://apps.apple.com/app/apple-store/id6745120053?pt=126797007&ct=Charade&mt=8',
         );
       },
       child: Container(


### PR DESCRIPTION
## Summary
- import url_launcher_string to use `launchUrlString`
- update app store link parameter

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688551ab73888329a98167073a431b4d