### PR TITLE
Fix spacing after closing Imposter banner

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -77,5 +77,7 @@
   "category_stars": "Stars",
   "category_intoxicants": "Drogen",
   "category_games": "Spiele",
-  "category_food": "Essen"
+  "category_food": "Essen",
+  "imposterTitle": "Imposter - das Partyspiel",
+  "imposterSubtitle": "Probiere unsere Imposter-App aus!"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -77,5 +77,7 @@
   "category_stars": "Stars",
   "category_intoxicants": "Intoxicants",
   "category_games": "Games",
-  "category_food": "Food"
+  "category_food": "Food",
+  "imposterTitle": "Imposter - the party game",
+  "imposterSubtitle": "Try out our Imposter app!"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -77,5 +77,7 @@
   "category_stars": "Estrellas",
   "category_intoxicants": "Drogas",
   "category_games": "Juegos",
-  "category_food": "Comida"
+  "category_food": "Comida",
+  "imposterTitle": "Imposter - el juego de fiesta",
+  "imposterSubtitle": "\u00a1Prueba nuestra aplicaci\u00f3n Imposter!"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -77,5 +77,7 @@
   "category_stars": "Stars",
   "category_intoxicants": "Drogues",
   "category_games": "Jeux",
-  "category_food": "Nourriture"
+  "category_food": "Nourriture",
+  "imposterTitle": "Imposter - le jeu de soir\u00e9e",
+  "imposterSubtitle": "Essayez notre application Imposter !"
 }

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -77,5 +77,7 @@
   "category_stars": "Zvijezde",
   "category_intoxicants": "Droge",
   "category_games": "Igre",
-  "category_food": "Hrana"
+  "category_food": "Hrana",
+  "imposterTitle": "Imposter - igra za zabave",
+  "imposterSubtitle": "Isprobajte na\u0161u Imposter aplikaciju!"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -77,5 +77,7 @@
   "category_stars": "Stars",
   "category_intoxicants": "Intoxicants",
   "category_games": "Games",
-  "category_food": "Food"
+  "category_food": "Food",
+  "imposterTitle": "Imposter - o jogo de festa",
+  "imposterSubtitle": "Experimente nosso aplicativo Imposter!"
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -211,7 +211,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
               if (filteredImages.length > 12) ...[
-                const SizedBox(height: 16),
+                SizedBox(height: _showImposterBanner ? 16 : 10),
                 if (_showImposterBanner)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -409,19 +409,19 @@ class _HomeScreenState extends State<HomeScreen> {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.start,
-                    children: const [
+                    children: [
                       Text(
-                        'Imposter - the party game',
-                        style: TextStyle(
+                        AppLocalizations.of(context).t('imposterTitle'),
+                        style: const TextStyle(
                           color: Colors.white,
                           fontWeight: FontWeight.bold,
                           fontSize: 18,
                         ),
                       ),
-                      SizedBox(height: 2),
+                      const SizedBox(height: 2),
                       Text(
-                        'Try out our Imposter app!',
-                        style: TextStyle(color: Colors.white),
+                        AppLocalizations.of(context).t('imposterSubtitle'),
+                        style: const TextStyle(color: Colors.white),
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- adjust spacing when closing the Imposter banner
- localize banner text

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/screens/home_screen.dart lib/l10n/*.arb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688555b40e98832987ac0577a354db4f